### PR TITLE
upgrade movement including wall slide

### DIFF
--- a/Assets/Prefabs/Dust.prefab
+++ b/Assets/Prefabs/Dust.prefab
@@ -40,7 +40,7 @@ ParticleSystem:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 401661667691938386}
   serializedVersion: 7
-  lengthInSec: 0.2
+  lengthInSec: 0.1
   simulationSpeed: 1
   stopAction: 0
   cullingMode: 0
@@ -865,7 +865,7 @@ ParticleSystem:
     rateOverTime:
       serializedVersion: 2
       minMaxState: 0
-      scalar: 120
+      scalar: 240
       minScalar: 10
       maxCurve:
         serializedVersion: 2

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -1,5 +1,149 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2882895677230905950
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2054960093416321599}
+  - component: {fileID: 272186063119281252}
+  - component: {fileID: 1284786657716356245}
+  m_Layer: 8
+  m_Name: LeftWallCheck
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2054960093416321599
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2882895677230905950}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5349741901730615678}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &272186063119281252
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2882895677230905950}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: -0.5, y: 0.13}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.2, y: 0.5}
+  m_EdgeRadius: 0
+--- !u!114 &1284786657716356245
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2882895677230905950}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57f253df6a56fa3589b32f96c3a79cf3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  isOnWall: 0
+--- !u!1 &3689264963522906753
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8401029214696933925}
+  - component: {fileID: 5624930178059829779}
+  - component: {fileID: 7970790820423634476}
+  m_Layer: 8
+  m_Name: GroundCheck
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8401029214696933925
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3689264963522906753}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5349741901730615678}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &5624930178059829779
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3689264963522906753}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: -0.54}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.9, y: 0.1}
+  m_EdgeRadius: 0
+--- !u!114 &7970790820423634476
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3689264963522906753}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fbd30fd0411cc3848b3f8fdfb39f4a17, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hasLanded: 0
+  isOnGround: 0
+  playerJumpState: 3
 --- !u!1 &5349741900707771351
 GameObject:
   m_ObjectHideFlags: 0
@@ -94,9 +238,9 @@ GameObject:
   - component: {fileID: 5349741901730615648}
   - component: {fileID: 5349741901730615649}
   - component: {fileID: 5349741901730615650}
-  - component: {fileID: 5349741901730615651}
   - component: {fileID: 6083185996628245252}
   - component: {fileID: 6467107586168053277}
+  - component: {fileID: 3562038053273634005}
   m_Layer: 8
   m_Name: Player
   m_TagString: Untagged
@@ -117,6 +261,9 @@ Transform:
   m_Children:
   - {fileID: 5349741900707771350}
   - {fileID: 2543039434040193013}
+  - {fileID: 8401029214696933925}
+  - {fileID: 2054960093416321599}
+  - {fileID: 3012638163539282029}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -133,7 +280,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 1
   m_UsedByComposite: 0
-  m_Offset: {x: -0.0019652843, y: 0.003930673}
+  m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -144,7 +291,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.9646239, y: 0.9449706}
+  m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
 --- !u!50 &5349741901730615649
 Rigidbody2D:
@@ -165,7 +312,7 @@ Rigidbody2D:
   m_Material: {fileID: 0}
   m_Interpolate: 0
   m_SleepingMode: 1
-  m_CollisionDetection: 1
+  m_CollisionDetection: 0
   m_Constraints: 4
 --- !u!251 &5349741901730615650
 PlatformEffector2D:
@@ -186,25 +333,6 @@ PlatformEffector2D:
   m_UseSideFriction: 0
   m_UseSideBounce: 0
   m_SideArc: 1
---- !u!114 &5349741901730615651
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5349741901730615679}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 04b1fba2a8819674da2d2b0c29e5dc56, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  movementSpeed: 7
-  jumpSpeed: 11
-  maxJumps: 2
-  jumpsAvailable: 0
-  dustParticles: {fileID: 5741215150046993374}
 --- !u!114 &6083185996628245252
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -239,6 +367,100 @@ MonoBehaviour:
   localPositionSensitivity: 0.01
   localRotationSensitivity: 0.01
   localScaleSensitivity: 0.01
+--- !u!114 &3562038053273634005
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5349741901730615679}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 04b1fba2a8819674da2d2b0c29e5dc56, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  movementSpeed: 7
+  jumpSpeed: 11
+  maxJumps: 2
+  jumpsAvailable: 0
+  wallRideSpeed: 0.1
+  dustParticles: {fileID: 5741215150046993374}
+  groundCheck: {fileID: 3689264963522906753}
+  LeftWallCheck: {fileID: 2882895677230905950}
+  RightWallCheck: {fileID: 8948432574415739495}
+--- !u!1 &8948432574415739495
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3012638163539282029}
+  - component: {fileID: 3702400484543652662}
+  - component: {fileID: 6291017147246764969}
+  m_Layer: 8
+  m_Name: RightWallCheck
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3012638163539282029
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8948432574415739495}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5349741901730615678}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &3702400484543652662
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8948432574415739495}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.5, y: 0.13}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.2, y: 0.5}
+  m_EdgeRadius: 0
+--- !u!114 &6291017147246764969
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8948432574415739495}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57f253df6a56fa3589b32f96c3a79cf3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  isOnWall: 0
 --- !u!1001 &5349741900763961740
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -296,13 +518,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f287bf71e463ecb6499242e07dfaa7ef, type: 3}
---- !u!1 &5741215150046993374 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 401661667691938386, guid: f287bf71e463ecb6499242e07dfaa7ef, type: 3}
-  m_PrefabInstance: {fileID: 5349741900763961740}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &2543039434040193013 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7598884350499337849, guid: f287bf71e463ecb6499242e07dfaa7ef, type: 3}
+  m_PrefabInstance: {fileID: 5349741900763961740}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &5741215150046993374 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 401661667691938386, guid: f287bf71e463ecb6499242e07dfaa7ef, type: 3}
   m_PrefabInstance: {fileID: 5349741900763961740}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -70,7 +70,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 57f253df6a56fa3589b32f96c3a79cf3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  isOnWall: 0
+  isTouchingWall: 0
+  hasPushedOffWall: 0
 --- !u!1 &3689264963522906753
 GameObject:
   m_ObjectHideFlags: 0
@@ -142,8 +143,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   hasLanded: 0
-  isOnGround: 0
-  playerJumpState: 3
+  hasLeftGround: 0
 --- !u!1 &5349741900707771351
 GameObject:
   m_ObjectHideFlags: 0
@@ -240,7 +240,7 @@ GameObject:
   - component: {fileID: 5349741901730615650}
   - component: {fileID: 6083185996628245252}
   - component: {fileID: 6467107586168053277}
-  - component: {fileID: 3562038053273634005}
+  - component: {fileID: 3381846885463958275}
   m_Layer: 8
   m_Name: Player
   m_TagString: Untagged
@@ -367,7 +367,7 @@ MonoBehaviour:
   localPositionSensitivity: 0.01
   localRotationSensitivity: 0.01
   localScaleSensitivity: 0.01
---- !u!114 &3562038053273634005
+--- !u!114 &3381846885463958275
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -385,7 +385,9 @@ MonoBehaviour:
   jumpSpeed: 11
   maxJumps: 2
   jumpsAvailable: 0
-  wallRideSpeed: 0.1
+  jumpDecrementThresholdVelocity: -0.05
+  wallSlideTriggerVelocity: 0.1
+  wallSlideVelocity: -0.1
   dustParticles: {fileID: 5741215150046993374}
   groundCheck: {fileID: 3689264963522906753}
   LeftWallCheck: {fileID: 2882895677230905950}
@@ -460,7 +462,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 57f253df6a56fa3589b32f96c3a79cf3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  isOnWall: 0
+  isTouchingWall: 0
+  hasPushedOffWall: 0
 --- !u!1001 &5349741900763961740
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 272186063119281252}
   - component: {fileID: 1284786657716356245}
   m_Layer: 8
-  m_Name: LeftWallCheck
+  m_Name: WallCheck
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -45,7 +45,7 @@ BoxCollider2D:
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: -0.5, y: 0.13}
+  m_Offset: {x: 0.5, y: 0.13}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -212,8 +212,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1102086627
+  m_SortingLayer: 2
   m_SortingOrder: 0
   m_Sprite: {fileID: 7769453424612927293, guid: f21136dd1f1e87e48b7f2258c6971a35, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -263,7 +263,6 @@ Transform:
   - {fileID: 2543039434040193013}
   - {fileID: 8401029214696933925}
   - {fileID: 2054960093416321599}
-  - {fileID: 3012638163539282029}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -385,85 +384,12 @@ MonoBehaviour:
   jumpSpeed: 11
   maxJumps: 2
   jumpsAvailable: 0
-  jumpDecrementThresholdVelocity: -0.05
-  wallSlideTriggerVelocity: 0.1
+  jumpDecrementThresholdVelocity: -3
+  wallSlideTriggerVelocity: 0.2
   wallSlideVelocity: -0.1
   dustParticles: {fileID: 5741215150046993374}
-  groundCheck: {fileID: 3689264963522906753}
-  LeftWallCheck: {fileID: 2882895677230905950}
-  RightWallCheck: {fileID: 8948432574415739495}
---- !u!1 &8948432574415739495
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3012638163539282029}
-  - component: {fileID: 3702400484543652662}
-  - component: {fileID: 6291017147246764969}
-  m_Layer: 8
-  m_Name: RightWallCheck
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3012638163539282029
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8948432574415739495}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 5349741901730615678}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!61 &3702400484543652662
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8948432574415739495}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0.5, y: 0.13}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 0.2, y: 0.5}
-  m_EdgeRadius: 0
---- !u!114 &6291017147246764969
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8948432574415739495}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 57f253df6a56fa3589b32f96c3a79cf3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  isTouchingWall: 0
-  hasPushedOffWall: 0
+  GroundCheck: {fileID: 3689264963522906753}
+  WallCheck: {fileID: 2882895677230905950}
 --- !u!1001 &5349741900763961740
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -474,6 +400,22 @@ PrefabInstance:
     - target: {fileID: 401661667691938386, guid: f287bf71e463ecb6499242e07dfaa7ef, type: 3}
       propertyPath: m_Name
       value: Dust
+      objectReference: {fileID: 0}
+    - target: {fileID: 401661667691938386, guid: f287bf71e463ecb6499242e07dfaa7ef, type: 3}
+      propertyPath: m_Layer
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 5074990410627740031, guid: f287bf71e463ecb6499242e07dfaa7ef, type: 3}
+      propertyPath: m_SortingLayerID
+      value: -1102086627
+      objectReference: {fileID: 0}
+    - target: {fileID: 5074990410627740031, guid: f287bf71e463ecb6499242e07dfaa7ef, type: 3}
+      propertyPath: m_SortingLayer
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5074990410627740031, guid: f287bf71e463ecb6499242e07dfaa7ef, type: 3}
+      propertyPath: m_SortingOrder
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7598884350499337849, guid: f287bf71e463ecb6499242e07dfaa7ef, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Prefabs/World Grid.prefab
+++ b/Assets/Prefabs/World Grid.prefab
@@ -14,7 +14,6 @@ GameObject:
   - component: {fileID: 5967766071218179133}
   - component: {fileID: 5967766071218179122}
   - component: {fileID: 5967766071218179123}
-  - component: {fileID: 5967766071218179132}
   m_Layer: 9
   m_Name: Foreground
   m_TagString: Untagged
@@ -7727,32 +7726,6 @@ CompositeCollider2D:
       - {x: 4.98389, y: -2.0161333}
   m_VertexDistance: 0.0005
   m_OffsetDistance: 0.00005
---- !u!61 &5967766071218179132
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5967766071218179127}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: -4, y: 3}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 30.032257, y: 16.032257}
-  m_EdgeRadius: 0
 --- !u!1 &5967766071279774694
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -208,17 +208,25 @@ PrefabInstance:
       propertyPath: m_TileMatrixArray.Array.data[4].m_Data.e20
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179120, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179121, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.size
       value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.size
-      value: 4
+      value: 132
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[1].Array.size
-      value: 47
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[2].Array.size
@@ -238,19 +246,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[6].Array.size
-      value: 6
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.size
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[2].Y
-      value: -120161288
+      value: 79838712
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[3].X
-      value: 320161280
+      value: -140161296
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[3].Y
-      value: -120161288
+      value: 69838712
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[1].Array.data[0].X
@@ -626,11 +642,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[1].Array.data[46].Y
-      value: -79838712
+      value: -59838708
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[2].Array.data[0].X
-      value: 240161280
+      value: 150161280
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[2].Array.data[0].Y
@@ -638,7 +654,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[2].Array.data[1].X
-      value: 229838720
+      value: 139838720
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[2].Array.data[1].Y
@@ -646,7 +662,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[2].Array.data[2].X
-      value: 229838720
+      value: 139838720
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[2].Array.data[2].Y
@@ -654,7 +670,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[2].Array.data[3].X
-      value: 240161280
+      value: 150161280
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[2].Array.data[3].Y
@@ -662,7 +678,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[3].Array.data[0].X
-      value: 210161280
+      value: 240161280
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[3].Array.data[0].Y
@@ -670,7 +686,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[3].Array.data[1].X
-      value: 199838720
+      value: 229838720
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[3].Array.data[1].Y
@@ -678,7 +694,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[3].Array.data[2].X
-      value: 199838720
+      value: 229838720
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[3].Array.data[2].Y
@@ -686,7 +702,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[3].Array.data[3].X
-      value: 210161280
+      value: 240161280
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[3].Array.data[3].Y
@@ -694,7 +710,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[4].Array.data[0].X
-      value: 180161280
+      value: 210161280
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[4].Array.data[0].Y
@@ -702,7 +718,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[4].Array.data[1].X
-      value: 169838720
+      value: 199838720
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[4].Array.data[1].Y
@@ -710,7 +726,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[4].Array.data[2].X
-      value: 169838720
+      value: 199838720
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[4].Array.data[2].Y
@@ -718,7 +734,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[4].Array.data[3].X
-      value: 180161280
+      value: 210161280
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[4].Array.data[3].Y
@@ -726,7 +742,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[5].Array.data[0].X
-      value: 150161280
+      value: 180161280
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[5].Array.data[0].Y
@@ -734,7 +750,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[5].Array.data[1].X
-      value: 139838720
+      value: 169838720
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[5].Array.data[1].Y
@@ -742,7 +758,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[5].Array.data[2].X
-      value: 139838720
+      value: 169838720
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[5].Array.data[2].Y
@@ -750,7 +766,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[5].Array.data[3].X
-      value: 150161280
+      value: 180161280
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[5].Array.data[3].Y
@@ -758,23 +774,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[6].Array.data[0].X
-      value: 120161288
+      value: 120161296
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[6].Array.data[0].Y
-      value: 161290
+      value: -9838710
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[6].Array.data[1].X
-      value: 110161288
+      value: 120161288
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[6].Array.data[1].Y
-      value: 161288
+      value: -9838710
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[6].Array.data[2].X
-      value: 110161288
+      value: 120161288
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[6].Array.data[2].Y
@@ -782,43 +798,43 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[6].Array.data[3].X
-      value: 49838708
+      value: 110161288
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[6].Array.data[3].Y
-      value: 161290
+      value: 161288
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[6].Array.data[4].X
-      value: 49838708
+      value: 110161288
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[6].Array.data[4].Y
-      value: -20161290
+      value: 161290
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[6].Array.data[5].X
-      value: 120161288
+      value: 49838708
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[6].Array.data[5].Y
-      value: -20161290
+      value: 161290
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[0].y
-      value: -12.016129
+      value: -12.0161295
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[0].x
-      value: 21.983871
+      value: 13.9838705
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[1].x
-      value: 20.016129
+      value: 12.016129
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[2].x
-      value: 20.0161
+      value: 12.016099
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[2].y
@@ -826,111 +842,111 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[3].x
-      value: 17.983871
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[3].y
-      value: -4.9839
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[4].x
-      value: 17.983843
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[5].x
-      value: 16.016129
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[5].y
-      value: -7.983842
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[6].x
-      value: 16.0161
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[6].y
-      value: -4.983871
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[7].x
-      value: 13.983872
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[7].y
-      value: -4.9839
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[8].x
-      value: 13.983844
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[8].y
-      value: -7.9838715
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[9].x
-      value: 12.016129
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[9].y
-      value: -7.983842
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[10].x
-      value: 12.016099
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[10].y
-      value: -4.983871
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[11].x
       value: 1.016129
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[11].y
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[3].y
       value: -4.983842
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[12].x
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[4].x
       value: 1.0160996
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[12].y
-      value: -3.9838707
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[13].x
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[5].x
       value: -0.983871
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[13].y
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[5].y
       value: -3.9838417
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[14].x
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[6].x
       value: -0.9839004
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[14].y
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[6].y
       value: -2.983871
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[15].x
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[7].x
       value: -2.983871
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[15].y
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[7].y
       value: -2.9838417
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[16].x
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[8].x
       value: -2.9839005
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[16].y
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[8].y
       value: -1.983871
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[9].x
+      value: -4.983871
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[9].y
+      value: -1.9838417
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[10].x
+      value: -4.9839
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[10].y
+      value: -0.983871
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[11].x
+      value: -7.9838715
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[11].y
+      value: -0.9838416
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[12].x
+      value: -7.983842
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[12].y
+      value: 1.983871
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[13].x
+      value: -6.9838715
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[13].y
+      value: 1.9839004
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[14].x
+      value: -6.983842
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[14].y
+      value: 2.983871
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[15].x
+      value: -5.983871
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[15].y
+      value: 2.9839005
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[16].x
+      value: -5.983842
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[16].y
+      value: 3.9838707
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[17].x
@@ -938,75 +954,75 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[17].y
-      value: -1.9838417
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[18].x
-      value: -4.9839
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[18].y
-      value: -0.983871
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[19].x
-      value: -7.9838715
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[20].x
-      value: -7.983842
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[20].y
-      value: 1.983871
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[21].x
-      value: -6.9838715
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[21].y
-      value: 1.9839004
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[22].x
-      value: -6.983842
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[22].y
-      value: 2.983871
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[23].x
-      value: -5.983871
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[23].y
-      value: 2.9839005
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[24].x
-      value: -5.983842
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[24].y
-      value: 3.9838707
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[25].x
-      value: -4.983871
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[25].y
       value: 3.9839
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[26].x
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[18].x
       value: -4.983842
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[26].y
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[18].y
       value: 4.983871
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[19].x
+      value: 28.983871
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[20].x
+      value: 28.983843
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[20].y
+      value: 2.016129
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[21].x
+      value: 26.983871
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[21].y
+      value: 2.0160997
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[22].x
+      value: 26.983902
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[22].y
+      value: 0.9838711
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[23].x
+      value: 28.983871
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[23].y
+      value: 0.9838417
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[24].x
+      value: 28.983843
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[24].y
+      value: -0.983871
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[25].x
+      value: 24.983871
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[25].y
+      value: -0.9839003
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[26].x
+      value: 24.983902
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[26].y
+      value: -2.016129
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[27].x
@@ -1014,7 +1030,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[27].y
-      value: 4.983842
+      value: -2.0161583
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[28].x
@@ -1022,83 +1038,83 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[28].y
-      value: 2.016129
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[29].x
-      value: 26.983871
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[29].y
-      value: 2.0160997
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[30].x
-      value: 26.983902
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[30].y
-      value: 0.9838711
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[31].x
-      value: 28.983871
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[31].y
-      value: 0.9838417
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[32].x
-      value: 28.983843
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[32].y
-      value: -0.983871
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[33].x
-      value: 24.983871
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[33].y
-      value: -0.9839003
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[34].x
-      value: 24.983902
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[34].y
-      value: -2.016129
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[35].x
-      value: 28.983871
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[35].y
-      value: -2.0161583
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[36].x
-      value: 28.983843
-      objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[36].y
       value: -3.9838707
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[37].x
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[29].x
       value: 21.983871
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[37].y
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[29].y
       value: -3.9839
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[30].x
+      value: 21.983843
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[30].y
+      value: -7.9838715
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[31].x
+      value: 20.016129
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[31].y
+      value: -7.983842
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[32].x
+      value: 20.0161
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[32].y
+      value: -4.983871
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[33].x
+      value: 17.983871
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[33].y
+      value: -4.9839
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[34].x
+      value: 17.983843
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[34].y
+      value: -7.9838715
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[35].x
+      value: 16.016129
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[35].y
+      value: -7.983842
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[36].x
+      value: 16.0161
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[36].y
+      value: -4.983871
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[37].x
+      value: 13.983872
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[37].y
+      value: -4.9839
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[2].Array.data[0].x
-      value: 15.016099
+      value: 21.0161
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[2].Array.data[0].y
@@ -1106,7 +1122,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[2].Array.data[1].x
-      value: 15.016099
+      value: 21.0161
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[2].Array.data[1].y
@@ -1114,7 +1130,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[2].Array.data[2].x
-      value: 13.983872
+      value: 19.983871
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[2].Array.data[2].y
@@ -1122,7 +1138,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[2].Array.data[3].x
-      value: 13.983901
+      value: 19.983902
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[2].Array.data[3].y
@@ -1130,7 +1146,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[3].Array.data[0].x
-      value: 18.0161
+      value: 15.016099
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[3].Array.data[0].y
@@ -1138,7 +1154,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[3].Array.data[1].x
-      value: 18.0161
+      value: 15.016099
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[3].Array.data[1].y
@@ -1146,7 +1162,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[3].Array.data[2].x
-      value: 16.983871
+      value: 13.983872
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[3].Array.data[2].y
@@ -1154,7 +1170,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[3].Array.data[3].x
-      value: 16.9839
+      value: 13.983901
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[3].Array.data[3].y
@@ -1162,7 +1178,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[4].Array.data[0].x
-      value: 21.0161
+      value: 24.0161
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[4].Array.data[0].y
@@ -1170,7 +1186,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[4].Array.data[1].x
-      value: 21.0161
+      value: 24.0161
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[4].Array.data[1].y
@@ -1178,7 +1194,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[4].Array.data[2].x
-      value: 19.983871
+      value: 22.983871
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[4].Array.data[2].y
@@ -1186,7 +1202,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[4].Array.data[3].x
-      value: 19.983902
+      value: 22.983902
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[4].Array.data[3].y
@@ -1194,7 +1210,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[5].Array.data[0].x
-      value: 24.0161
+      value: 18.0161
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[5].Array.data[0].y
@@ -1202,7 +1218,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[5].Array.data[1].x
-      value: 24.0161
+      value: 18.0161
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[5].Array.data[1].y
@@ -1210,7 +1226,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[5].Array.data[2].x
-      value: 22.983871
+      value: 16.983871
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[5].Array.data[2].y
@@ -1218,7 +1234,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[5].Array.data[3].x
-      value: 22.983902
+      value: 16.9839
       objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[5].Array.data[3].y
@@ -1255,6 +1271,1146 @@ PrefabInstance:
     - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_CompositePaths.m_Paths.Array.data[6].Array.data[3].y
       value: -2.016129
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[0].X
+      value: 320161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[0].Y
+      value: 90161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[1].X
+      value: -140161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[1].Y
+      value: 90161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[2].X
+      value: -140161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[4].X
+      value: -140161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[4].Y
+      value: 69838712
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[5].X
+      value: -140161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[5].Y
+      value: 59838708
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[6].X
+      value: -140161281
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[6].Y
+      value: 59838708
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[7].X
+      value: -140161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[7].Y
+      value: 49838708
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[8].X
+      value: -140161281
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[8].Y
+      value: 49838708
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[9].X
+      value: -140161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[9].Y
+      value: 39838708
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[10].X
+      value: -140161281
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[10].Y
+      value: 39838708
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[11].X
+      value: -140161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[11].Y
+      value: 29838710
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[12].X
+      value: -140161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[12].Y
+      value: 29838710
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[13].X
+      value: -140161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[13].Y
+      value: 19838710
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[14].X
+      value: -140161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[14].Y
+      value: 19838710
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[15].X
+      value: -140161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[15].Y
+      value: 9838710
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[16].X
+      value: -140161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[16].Y
+      value: 9838710
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[17].X
+      value: -140161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[17].Y
+      value: -161289
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[18].X
+      value: -140161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[18].Y
+      value: -161289
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[19].X
+      value: -140161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[19].Y
+      value: -10161290
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[20].X
+      value: -140161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[20].Y
+      value: -10161290
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[21].X
+      value: -140161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[21].Y
+      value: -20161290
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[22].X
+      value: -140161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[22].Y
+      value: -20161290
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[23].X
+      value: -140161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[23].Y
+      value: -30161290
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[24].X
+      value: -140161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[24].Y
+      value: -30161290
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[25].X
+      value: -140161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[25].Y
+      value: -40161292
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[26].X
+      value: -140161281
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[26].Y
+      value: -40161292
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[27].X
+      value: -140161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[27].Y
+      value: -50161292
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[28].X
+      value: -140161281
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[28].Y
+      value: -50161292
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[29].X
+      value: -140161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[29].Y
+      value: -60161292
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[30].X
+      value: -140161281
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[30].Y
+      value: -60161292
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[31].X
+      value: -140161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[31].Y
+      value: -70161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[32].X
+      value: -140161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[32].Y
+      value: -70161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[33].X
+      value: -140161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[33].Y
+      value: -80161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[34].X
+      value: -140161281
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[34].Y
+      value: -80161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[35].X
+      value: -140161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[35].Y
+      value: -90161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[36].X
+      value: -140161281
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[36].Y
+      value: -90161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[37].X
+      value: -140161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[37].Y
+      value: -100161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[38].X
+      value: -140161281
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[38].Y
+      value: -100161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[39].X
+      value: -140161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[39].Y
+      value: -110161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[40].X
+      value: -140161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[40].Y
+      value: -110161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[41].X
+      value: -140161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[41].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[42].X
+      value: -130161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[42].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[43].X
+      value: -119838712
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[43].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[44].X
+      value: -119838712
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[44].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[45].X
+      value: -109838712
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[45].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[46].X
+      value: -109838712
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[46].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[47].X
+      value: -99838712
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[47].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[48].X
+      value: -99838712
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[48].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[49].X
+      value: -89838712
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[49].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[50].X
+      value: -89838712
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[50].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[51].X
+      value: -79838712
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[51].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[52].X
+      value: -79838712
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[52].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[53].X
+      value: -69838712
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[53].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[54].X
+      value: -69838712
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[54].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[55].X
+      value: -59838708
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[55].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[56].X
+      value: -59838708
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[56].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[57].X
+      value: -49838708
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[57].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[58].X
+      value: -49838708
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[58].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[59].X
+      value: -39838708
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[59].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[60].X
+      value: -39838708
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[60].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[61].X
+      value: -29838710
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[61].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[62].X
+      value: -29838710
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[62].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[63].X
+      value: -19838710
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[63].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[64].X
+      value: -19838710
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[64].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[65].X
+      value: -9838710
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[65].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[66].X
+      value: -9838710
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[66].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[67].X
+      value: 161289
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[67].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[68].X
+      value: 161289
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[68].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[69].X
+      value: 10161290
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[69].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[70].X
+      value: 10161290
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[70].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[71].X
+      value: 20161290
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[71].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[72].X
+      value: 20161290
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[72].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[73].X
+      value: 30161290
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[73].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[74].X
+      value: 30161290
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[74].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[75].X
+      value: 40161292
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[75].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[76].X
+      value: 40161292
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[76].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[77].X
+      value: 50161292
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[77].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[78].X
+      value: 50161292
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[78].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[79].X
+      value: 60161292
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[79].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[80].X
+      value: 60161292
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[80].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[81].X
+      value: 70161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[81].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[82].X
+      value: 70161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[82].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[83].X
+      value: 80161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[83].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[84].X
+      value: 80161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[84].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[85].X
+      value: 90161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[85].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[86].X
+      value: 90161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[86].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[87].X
+      value: 100161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[87].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[88].X
+      value: 100161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[88].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[89].X
+      value: 110161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[89].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[90].X
+      value: 110161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[90].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[91].X
+      value: 120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[91].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[92].X
+      value: 120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[92].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[93].X
+      value: 130161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[93].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[94].X
+      value: 130161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[94].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[95].X
+      value: 140161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[95].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[96].X
+      value: 140161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[96].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[97].X
+      value: 150161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[97].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[98].X
+      value: 150161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[98].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[99].X
+      value: 160161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[99].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[100].X
+      value: 160161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[100].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[101].X
+      value: 170161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[101].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[102].X
+      value: 170161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[102].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[103].X
+      value: 180161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[103].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[104].X
+      value: 180161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[104].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[105].X
+      value: 190161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[105].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[106].X
+      value: 190161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[106].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[107].X
+      value: 200161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[107].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[108].X
+      value: 200161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[108].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[109].X
+      value: 210161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[109].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[110].X
+      value: 210161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[110].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[111].X
+      value: 220161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[111].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[112].X
+      value: 220161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[112].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[113].X
+      value: 230161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[113].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[114].X
+      value: 230161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[114].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[115].X
+      value: 240161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[115].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[116].X
+      value: 240161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[116].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[117].X
+      value: 250161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[117].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[118].X
+      value: 250161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[118].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[119].X
+      value: 260161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[119].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[120].X
+      value: 260161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[120].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[121].X
+      value: 270161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[121].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[122].X
+      value: 270161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[122].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[123].X
+      value: 280161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[123].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[124].X
+      value: 280161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[124].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[125].X
+      value: 290161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[125].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[126].X
+      value: 290161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[126].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[127].X
+      value: 300161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[127].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[128].X
+      value: 300161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[128].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[129].X
+      value: 310161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[129].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[130].X
+      value: 310161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[130].Y
+      value: -120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[131].X
+      value: 320161280
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[131].Y
+      value: -120161296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[6].Array.data[6].X
+      value: 49838708
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[6].Array.data[6].Y
+      value: -20161290
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[6].Array.data[7].X
+      value: 120161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[6].Array.data[7].Y
+      value: -20161290
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[0].x
+      value: 32.016098
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[1].x
+      value: 32.016098
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[1].y
+      value: 9.016129
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[2].x
+      value: -14.016129
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[2].y
+      value: 9.016099
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[3].x
+      value: -14.016099
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[3].y
+      value: -12.016129
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[0].y
+      value: -7.983842
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[1].y
+      value: -7.983842
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[4].y
+      value: -3.9838707
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[1].Array.data[19].y
+      value: 4.983842
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[1].Array.data[47].X
+      value: 139838704
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[1].Array.data[47].Y
+      value: -70161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[1].Array.data[48].X
+      value: 139838720
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[1].Array.data[48].Y
+      value: -70161288
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[1].Array.data[49].X
+      value: 139838704
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179123, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[1].Array.data[49].Y
+      value: -79838712
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179127, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179132, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5967766071218179133, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+      propertyPath: m_Enabled
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5967766072828268608, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1304,7 +2460,8 @@ PrefabInstance:
       propertyPath: m_Name
       value: World Grid
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 5967766071218179132, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
 --- !u!1001 &8403614424264941647
 PrefabInstance:

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2404,10 +2404,6 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 9
       objectReference: {fileID: 0}
-    - target: {fileID: 5967766071218179132, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 5967766071218179133, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
       propertyPath: m_Enabled
       value: 1
@@ -2460,8 +2456,7 @@ PrefabInstance:
       propertyPath: m_Name
       value: World Grid
       objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 5967766071218179132, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
+    m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1b137550891e9764ebaafd9ed35a4300, type: 3}
 --- !u!1001 &8403614424264941647
 PrefabInstance:

--- a/Assets/Scripts/GroundCheck.cs
+++ b/Assets/Scripts/GroundCheck.cs
@@ -1,0 +1,38 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GroundCheck : MonoBehaviour
+{
+	private BoxCollider2D groundCheckBoxCollider;
+	public bool hasLanded;
+	public bool isOnGround;
+	public enum JumpState {
+		LANDED,
+		ONGROUND,
+		INAIR,
+		FALLING
+	}
+	public JumpState playerJumpState;
+
+	void Start() {
+		groundCheckBoxCollider = GetComponent<BoxCollider2D>();
+		playerJumpState = JumpState.INAIR;
+	}
+
+	public JumpState GetJumpState() {
+		return playerJumpState;
+	}
+
+	public void SetJumpState(JumpState js) {
+		playerJumpState = js;
+	}
+
+	void OnTriggerEnter2D(Collider2D col) {
+		SetJumpState(JumpState.LANDED);
+	}
+
+	void OnTriggerExit2D(Collider2D col) {
+		SetJumpState(JumpState.FALLING);
+	}
+}

--- a/Assets/Scripts/GroundCheck.cs
+++ b/Assets/Scripts/GroundCheck.cs
@@ -6,37 +6,41 @@ public class GroundCheck : MonoBehaviour
 {
 	private BoxCollider2D groundCheckBoxCollider;
 	public bool hasLanded;
-	public bool isOnGround;
-	public enum JumpState {
-		LANDED,
-		ONGROUND,
-		INAIR,
-		FALLING
-	}
-	public JumpState playerJumpState;
-
+	public bool hasLeftGround;
+	
 	void Start() {
 		groundCheckBoxCollider = GetComponent<BoxCollider2D>();
-		playerJumpState = JumpState.INAIR;
+		hasLanded = false;
+		hasLeftGround = false;
 	}
 
-	public JumpState GetJumpState() {
-		return playerJumpState;
+	public bool GetHasLanded() {
+		return hasLanded;
 	}
 
-	public void SetJumpState(JumpState js) {
-		playerJumpState = js;
+	public void SetHasLanded(bool b) {
+		hasLanded = b;
+	}
+
+	public bool GetHasLeftGround() {
+		return hasLeftGround;
+	}
+
+	public void SetHasLeftGround(bool b) {
+		hasLeftGround = b;
 	}
 
 	void OnTriggerEnter2D(Collider2D other) {
 		if (other.gameObject.layer == LayerMask.NameToLayer ("Ground")) {
-			SetJumpState(JumpState.LANDED);
+			hasLanded = true;
 		}
 	}
 
 	void OnTriggerExit2D(Collider2D other) {
 		if (other.gameObject.layer == LayerMask.NameToLayer ("Ground")) {
-			SetJumpState(JumpState.FALLING);
+			hasLeftGround = true;
 		}
 	}
+
+	
 }

--- a/Assets/Scripts/GroundCheck.cs
+++ b/Assets/Scripts/GroundCheck.cs
@@ -28,11 +28,15 @@ public class GroundCheck : MonoBehaviour
 		playerJumpState = js;
 	}
 
-	void OnTriggerEnter2D(Collider2D col) {
-		SetJumpState(JumpState.LANDED);
+	void OnTriggerEnter2D(Collider2D other) {
+		if (other.gameObject.layer == LayerMask.NameToLayer ("Ground")) {
+			SetJumpState(JumpState.LANDED);
+		}
 	}
 
-	void OnTriggerExit2D(Collider2D col) {
-		SetJumpState(JumpState.FALLING);
+	void OnTriggerExit2D(Collider2D other) {
+		if (other.gameObject.layer == LayerMask.NameToLayer ("Ground")) {
+			SetJumpState(JumpState.FALLING);
+		}
 	}
 }

--- a/Assets/Scripts/GroundCheck.cs
+++ b/Assets/Scripts/GroundCheck.cs
@@ -4,12 +4,10 @@ using UnityEngine;
 
 public class GroundCheck : MonoBehaviour
 {
-	private BoxCollider2D groundCheckBoxCollider;
 	public bool hasLanded;
 	public bool hasLeftGround;
 	
 	void Start() {
-		groundCheckBoxCollider = GetComponent<BoxCollider2D>();
 		hasLanded = false;
 		hasLeftGround = false;
 	}

--- a/Assets/Scripts/GroundCheck.cs.meta
+++ b/Assets/Scripts/GroundCheck.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fbd30fd0411cc3848b3f8fdfb39f4a17
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -10,12 +10,13 @@ public class Player : NetworkBehaviour {
 	[SerializeField] float jumpSpeed = 7f;
 	[SerializeField] int maxJumps = 2;
 	[SerializeField] int jumpsAvailable;
-	[SerializeField] float wallRideTriggerSpeed = 0.1f; //upward direction
-	[SerializeField] float wallRideSpeed = -0.1f; //downward direction
+	[SerializeField] float wallslideTriggerSpeed = 0.1f; //upward direction
+	[SerializeField] float wallslideSpeed = -0.1f; //downward direction
 	
 	// GameObject instead of particle system to pass into a server command
 	[SerializeField] private GameObject dustParticles;
 	
+	// Ground and wall checks are preformed with the following gameobjects.
 	[SerializeField] private GameObject groundCheck;
 	private GroundCheck groundCheckScript;
 	[SerializeField] private GameObject LeftWallCheck;
@@ -61,15 +62,18 @@ public class Player : NetworkBehaviour {
 	void Update() {
 		if (hasAuthority) {
 			Debug.Log(GetJumpState());
+			// the order of these operations is important due to them changing the "JumpState" of the player.
 			handleLanding();
 			handleJump();
-			handleWallRide();
+			handleWallslide();
 			handleMovement();
 		}
 	}
 
 	private void handleLanding() {
 		if (GetJumpState() == GroundCheck.JumpState.LANDED) {
+			// As soon as landing has been detected, it should perform the following lines once
+			// and then immediately change the JumpState to ONGROUND, so these line won't run again.
 			jumpsAvailable = maxJumps;
 			CmdPlayDustParticles();
 			SetJumpState(GroundCheck.JumpState.ONGROUND);
@@ -89,6 +93,7 @@ public class Player : NetworkBehaviour {
 			Vector2 jumpVelocity = new Vector2(rb.velocity.x, jumpSpeed);
 			rb.velocity = jumpVelocity;
 			jumpsAvailable--;
+			// The following lines ensure that when the player falls off the edge and tries to jump, his available jumps decrements twice.
 			if (GetJumpState() == GroundCheck.JumpState.FALLING) {
 				jumpsAvailable--;
 				SetJumpState(GroundCheck.JumpState.INAIR);
@@ -96,14 +101,15 @@ public class Player : NetworkBehaviour {
 		}
 	}
 
-	private void handleWallRide() {
+	private void handleWallslide() {
+		// if player is moving left onto a left wall or moving right onto a right wall, wall sliding will activate.
 		if ((GetIsOnLeftWall() && Input.GetAxisRaw("Horizontal") < 0) ||
 			(GetIsOnRightWall() && Input.GetAxisRaw("Horizontal") > 0)) {
-			if (rb.velocity.y < wallRideTriggerSpeed) {
+			if (rb.velocity.y < wallslideTriggerSpeed) {
 				SetJumpState(GroundCheck.JumpState.LANDED);
 				CmdPlayDustParticles();
-				if (rb.velocity.y < wallRideSpeed) {
-					Vector2 slideVelocity = new Vector2(rb.velocity.x, wallRideSpeed);
+				if (rb.velocity.y < wallslideSpeed) {
+					Vector2 slideVelocity = new Vector2(rb.velocity.x, wallslideSpeed);
 					rb.velocity = slideVelocity;
 				}
 			}

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using Cinemachine;
 using Mirror;
@@ -6,33 +6,24 @@ using UnityEngine;
 
 public class Player : NetworkBehaviour {
 	[SerializeField] float movementSpeed = 7f;
-	[SerializeField] float jumpSpeed = 7f;
+	[SerializeField] float jumpSpeed = 13f;
 	[SerializeField] int maxJumps = 2;
 	[SerializeField] int jumpsAvailable;
-	[SerializeField] float jumpDecrementThresholdSpeed = -0.05f; //gives a buffer time when falling off a cliff before jump count will decrement
-	[SerializeField] float wallSlideTriggerSpeed = 0.1f; //upward direction
-	[SerializeField] float wallSlideSpeed = -0.1f; //downward direction
-	public enum JumpState {
-		LANDED,
-		ONGROUND,
-		INAIR,
-		FALLING
-	}
-	[SerializeField] public JumpState playerJumpState;
-
+	[SerializeField] float jumpDecrementThresholdVelocity = -0.05f; //when falling off a cliff, gives a buffer time before jump count will decrement
+	[SerializeField] float wallSlideTriggerVelocity = 0.1f; //upward direction
+	[SerializeField] float wallSlideVelocity = -0.1f; //downward direction
+	bool isFalling;
 
 	// GameObject instead of particle system to pass into a server command
 	[SerializeField] private GameObject dustParticles;
 	
-	// Ground and wall checks are preformed with the following gameobjects.
+	// Ground and wall checks are performed with the following gameobjects.
 	[SerializeField] private GameObject groundCheck;
 	private GroundCheck groundCheckScript;
 	[SerializeField] private GameObject LeftWallCheck;
 	private WallCheck leftWallCheckScript;
 	[SerializeField] private GameObject RightWallCheck;
 	private WallCheck rightWallCheckScript;
-
-	
 
 	private Rigidbody2D rb;
 	private BoxCollider2D boxCollider;
@@ -42,7 +33,7 @@ public class Player : NetworkBehaviour {
 		rb = GetComponent<Rigidbody2D>();
 		boxCollider = GetComponent<BoxCollider2D>();
 		jumpsAvailable = maxJumps;
-		playerJumpState = JumpState.FALLING;
+		isFalling = true;
 
 		//load scripts from groundCheck and LeftWallCheck gameobjects
 		groundCheckScript = groundCheck.GetComponent<GroundCheck>();
@@ -72,27 +63,31 @@ public class Player : NetworkBehaviour {
 	// Update is called once per frame
 	void Update() {
 		if (hasAuthority) {
-			Debug.Log(playerJumpState);
-			// the order of these operations is important due to them changing the "JumpState" of the player.
-			// checkLanding();
-			handleLanding(); // player can land either on the ground or the wall - both activate the same behaviour
+			detectLanding();
+			detectFalling();
 			handleJump();
 			handleWallSlide();
 			handleMovement();
 		}
 	}
 
-	private void handleLanding() {
+	private void detectLanding() {
 		if (GetHasLanded()) {
-			playerJumpState = JumpState.LANDED;
-			SetHasLanded(false);
-		} 
-		if (playerJumpState == JumpState.LANDED) {
-			// As soon as landing has been detected, it should perform the following lines once
-			// and then immediately change the JumpState to ONGROUND, so these line won't run again.
 			jumpsAvailable = maxJumps;
 			CmdPlayDustParticles();
-			playerJumpState = JumpState.ONGROUND;
+			SetHasLanded(false);
+			isFalling = false;
+		} 
+	}
+
+	private void detectFalling() {
+		if (!isFalling && GetHasLeftGround() && rb.velocity.y < jumpDecrementThresholdVelocity) {
+			isFalling = true;
+			SetHasLeftGround(false);
+		}
+		if (!isFalling && GetHasPushedOffWall() && rb.velocity.y < jumpDecrementThresholdVelocity+wallSlideVelocity) {
+			isFalling = true;
+			SetHasPushedOffWall(false);
 		}
 	}
 
@@ -105,60 +100,31 @@ public class Player : NetworkBehaviour {
 		if (jumpsAvailable <= 0) {
 			return;
 		}
-		if (GetHasLeftGround()) {
-			// If GroundCheck detects that player is no longer on firm ground and the velocity is decreasing,
-			// then the player is falling rather than jumping.
-			if (rb.velocity.y < jumpDecrementThresholdSpeed) {
-				playerJumpState = JumpState.FALLING;
-			}
-			else {
-				playerJumpState = JumpState.INAIR;
-			}
-			SetHasLeftGround(false);
-		}
-		if (GetHasPushedOffWall()) {
-			if (rb.velocity.y < jumpDecrementThresholdSpeed + wallSlideSpeed) {
-				playerJumpState = JumpState.FALLING;
-			}
-			else {
-				playerJumpState = JumpState.INAIR;
-			}
-			SetHasPushedOffWall(false);
-		}
 		if (Input.GetButtonDown("Jump")) {
 			Vector2 jumpVelocity = new Vector2(rb.velocity.x, jumpSpeed);
 			rb.velocity = jumpVelocity;
-			jumpsAvailable--;
-			// The following lines ensure that when the player falls off the edge and tries to jump, his available jumps decrements twice.
-			if (playerJumpState == JumpState.FALLING) {
+			if (isFalling) {
 				jumpsAvailable--;
-				playerJumpState = JumpState.INAIR;
+				isFalling = false;
 			}
+			jumpsAvailable--;
 		}
 	}
 
 	private void handleWallSlide() {
 		// if player is moving left onto a left wall or moving right onto a right wall, wall sliding will activate.
-		if ((GetHasTouchedLeftWall() && Input.GetAxisRaw("Horizontal") < 0) ||
-			(GetHasTouchedRightWall() && Input.GetAxisRaw("Horizontal") > 0)) {
-			if (rb.velocity.y < wallSlideTriggerSpeed) {
-				playerJumpState = JumpState.LANDED;
-				Debug.Log("Landing occurred...");
+		if (rb.velocity.y < wallSlideTriggerVelocity) {
+			if ((GetIsTouchingLeftWall() && Input.GetAxisRaw("Horizontal") < 0) ||
+				(GetIsTouchingRightWall() && Input.GetAxisRaw("Horizontal") > 0)) {
 				CmdPlayDustParticles();
-				if (rb.velocity.y < wallSlideSpeed) {
-					Vector2 slideVelocity = new Vector2(rb.velocity.x, wallSlideSpeed);
+				isFalling = false;
+				jumpsAvailable = maxJumps;
+				if (rb.velocity.y < wallSlideVelocity) {
+					Vector2 slideVelocity = new Vector2(rb.velocity.x, wallSlideVelocity);
 					rb.velocity = slideVelocity;
 				}
 			}
 		}
-		// else if (GetHasTouchedLeftWall() || GetHasTouchedRightWall()) {
-		// 	playerJumpState = JumpState.ONGROUND;
-		// }
-
-		// if (GetHasPushedOffWall() && rb.velocity.y < jumpDecrementThresholdSpeed) {
-		// 	playerJumpState = JumpState.FALLING;
-		// 	SetHasPushedOffWall(false);
-		// }
 	}
 
 	// Run on server so every player can see the dust particles
@@ -189,26 +155,25 @@ public class Player : NetworkBehaviour {
 		groundCheckScript.SetHasLeftGround(b);
 	}
 
-	private bool GetHasTouchedLeftWall() {
-		return leftWallCheckScript.GetHasTouchedWall();
+	private bool GetIsTouchingLeftWall() {
+		return leftWallCheckScript.GetIsTouchingWall();
 	}
 
-	private bool GetHasTouchedRightWall() {
-		return rightWallCheckScript.GetHasTouchedWall();
+	private bool GetIsTouchingRightWall() {
+		return rightWallCheckScript.GetIsTouchingWall();
 	}
 
-	private void SetHasTouchedWall(bool b) {
-		leftWallCheckScript.SetHasTouchedWall(b);
-		rightWallCheckScript.SetHasTouchedWall(b);
+	private void SetIsTouchingWall(bool b) {
+		leftWallCheckScript.SetIsTouchingWall(b);
+		rightWallCheckScript.SetIsTouchingWall(b);
 	}
 
 	private bool GetHasPushedOffWall() {
-		return leftWallCheckScript.GetHasTouchedWall() || rightWallCheckScript.GetHasTouchedWall();
+		return leftWallCheckScript.GetHasPushedOffWall() || rightWallCheckScript.GetHasPushedOffWall();
 	}
 
 	private void SetHasPushedOffWall(bool b) {
 		rightWallCheckScript.SetHasPushedOffWall(b);
 		leftWallCheckScript.SetHasPushedOffWall(b);
 	}
-
 }

--- a/Assets/Scripts/WallCheck.cs
+++ b/Assets/Scripts/WallCheck.cs
@@ -5,26 +5,42 @@ using UnityEngine;
 public class WallCheck : MonoBehaviour
 {
 	private BoxCollider2D wallCheckBoxCollider;
-	public bool isOnWall;
+	public bool hasTouchedWall;
+	public bool hasPushedOffWall;
 
 	void Start() {
 		wallCheckBoxCollider = GetComponent<BoxCollider2D>();
-		isOnWall = false;
+		hasTouchedWall = false;
+		hasPushedOffWall = false;
 	}
 
-	public bool GetIsOnWall() {
-		return isOnWall;
+	public bool GetHasTouchedWall() {
+		return hasTouchedWall;
 	}
+
+	public void SetHasTouchedWall(bool b) {
+		hasTouchedWall = b;
+	}
+
+	public bool GetHasPushedOffWall() {
+		return hasPushedOffWall;
+	}
+
+	public void SetHasPushedOffWall(bool b) {
+		hasPushedOffWall = b;
+	}
+
 
 	void OnTriggerEnter2D(Collider2D other) {
 		if (other.gameObject.layer == LayerMask.NameToLayer ("Ground")) {
-			isOnWall = true;
+			hasTouchedWall = true;
 		}
 	}
 
 	void OnTriggerExit2D(Collider2D other) {
 		if (other.gameObject.layer == LayerMask.NameToLayer ("Ground")) {
-			isOnWall = false;
+			hasTouchedWall = false;
+			hasPushedOffWall = true;
 		}
 	}
 }

--- a/Assets/Scripts/WallCheck.cs
+++ b/Assets/Scripts/WallCheck.cs
@@ -1,0 +1,26 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class WallCheck : MonoBehaviour
+{
+	private BoxCollider2D wallCheckBoxCollider;
+	public bool isOnWall;
+
+	void Start() {
+		wallCheckBoxCollider = GetComponent<BoxCollider2D>();
+		isOnWall = false;
+	}
+
+	public bool GetIsOnWall() {
+		return isOnWall;
+	}
+
+	void OnTriggerEnter2D(Collider2D col) {
+		isOnWall = true;
+	}
+
+	void OnTriggerExit2D(Collider2D col) {
+		isOnWall = false;
+	}
+}

--- a/Assets/Scripts/WallCheck.cs
+++ b/Assets/Scripts/WallCheck.cs
@@ -34,7 +34,6 @@ public class WallCheck : MonoBehaviour
 	void OnTriggerStay2D(Collider2D other) {
 		if (other.gameObject.layer == LayerMask.NameToLayer ("Ground")) {
 			isTouchingWall = true;
-			Debug.Log("touching a wall");
 		}
 	}
 

--- a/Assets/Scripts/WallCheck.cs
+++ b/Assets/Scripts/WallCheck.cs
@@ -5,21 +5,21 @@ using UnityEngine;
 public class WallCheck : MonoBehaviour
 {
 	private BoxCollider2D wallCheckBoxCollider;
-	public bool hasTouchedWall;
+	public bool isTouchingWall;
 	public bool hasPushedOffWall;
 
 	void Start() {
 		wallCheckBoxCollider = GetComponent<BoxCollider2D>();
-		hasTouchedWall = false;
+		isTouchingWall = false;
 		hasPushedOffWall = false;
 	}
 
-	public bool GetHasTouchedWall() {
-		return hasTouchedWall;
+	public bool GetIsTouchingWall() {
+		return isTouchingWall;
 	}
 
-	public void SetHasTouchedWall(bool b) {
-		hasTouchedWall = b;
+	public void SetIsTouchingWall(bool b) {
+		isTouchingWall = b;
 	}
 
 	public bool GetHasPushedOffWall() {
@@ -31,15 +31,16 @@ public class WallCheck : MonoBehaviour
 	}
 
 
-	void OnTriggerEnter2D(Collider2D other) {
+	void OnTriggerStay2D(Collider2D other) {
 		if (other.gameObject.layer == LayerMask.NameToLayer ("Ground")) {
-			hasTouchedWall = true;
+			isTouchingWall = true;
+			Debug.Log("touching a wall");
 		}
 	}
 
 	void OnTriggerExit2D(Collider2D other) {
 		if (other.gameObject.layer == LayerMask.NameToLayer ("Ground")) {
-			hasTouchedWall = false;
+			isTouchingWall = false;
 			hasPushedOffWall = true;
 		}
 	}

--- a/Assets/Scripts/WallCheck.cs
+++ b/Assets/Scripts/WallCheck.cs
@@ -16,11 +16,15 @@ public class WallCheck : MonoBehaviour
 		return isOnWall;
 	}
 
-	void OnTriggerEnter2D(Collider2D col) {
-		isOnWall = true;
+	void OnTriggerEnter2D(Collider2D other) {
+		if (other.gameObject.layer == LayerMask.NameToLayer ("Ground")) {
+			isOnWall = true;
+		}
 	}
 
-	void OnTriggerExit2D(Collider2D col) {
-		isOnWall = false;
+	void OnTriggerExit2D(Collider2D other) {
+		if (other.gameObject.layer == LayerMask.NameToLayer ("Ground")) {
+			isOnWall = false;
+		}
 	}
 }

--- a/Assets/Scripts/WallCheck.cs.meta
+++ b/Assets/Scripts/WallCheck.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 57f253df6a56fa3589b32f96c3a79cf3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -44,6 +44,9 @@ TagManager:
   - name: Background
     uniqueID: 2662829117
     locked: 0
+  - name: Player
+    uniqueID: 3192880669
+    locked: 0
   - name: Foreground
     uniqueID: 2171385487
     locked: 0
@@ -52,4 +55,7 @@ TagManager:
     locked: 0
   - name: Objects
     uniqueID: 3783772583
+    locked: 0
+  - name: UI
+    uniqueID: 150930573
     locked: 0


### PR DESCRIPTION
There has been major changes in player script especially regarding movement and ground detection.
- Raycast was replaced with a regular collision box, as I am more familiar with this method
- This branch introduces "Jump States", which is like a FSM which was necessary to compute the number of jumps left in different states of the play.
- ground check + wall check logic were separated from the player script. They both live in separate game objects which are children of the player game object. We may want to refactor later to make one (Singleton?) script that handles the JumpState, but it's not an issue currently.
- Dust particles should appear on either side of the player when wall sliding, but I reused the ground dust particles for now.